### PR TITLE
Indexing 

### DIFF
--- a/CompoundIndex.js
+++ b/CompoundIndex.js
@@ -1,0 +1,4 @@
+db.student.createIndex({"age":1,"grd_point":1})
+
+#to get all the indexes
+db.student.getIndexes()

--- a/DropIndex.js
+++ b/DropIndex.js
@@ -1,0 +1,1 @@
+db.student.dropIndex({key: {student_id: 942091}})

--- a/GeospatialIndex.js
+++ b/GeospatialIndex.js
@@ -1,0 +1,3 @@
+db.grades.createIndex({"score":"2dsphere"})
+
+db.grades.getIndexes()

--- a/MultiKeyIndex.js
+++ b/MultiKeyIndex.js
@@ -1,0 +1,3 @@
+db.grades.createIndex({"products":1})
+
+db.grades.getIndexes()

--- a/SingleFieldIndex.js
+++ b/SingleFieldIndex.js
@@ -1,0 +1,11 @@
+db.student.createIndex({"age":-1},
+{
+"createdCollectionAutomatically" : false,
+"numIndexesBefore" : 1,
+"numIndexesAfter" : 2,
+"ok" : 1
+} )
+
+#to list all the indexes
+
+db.student.getIndexes()


### PR DESCRIPTION
Indexing in MongoDB
Indexing in MongoDB is essential for optimizing database performance by enhancing the efficiency of query operations. MongoDB offers various types of indexes to suit different data and query requirements:
1.Single Field Index:
A single field index is created on a single field within a document in a MongoDB collection.It improves query performance when filtering or sorting by a specific field.
2.Compound Index:
A compound index is created on multiple fields within a document. Useful for queries involving multiple criteria or simultaneous sorting and filtering on multiple fields.
3.Multi-Key Index:
Created on array fields where each element of the array is indexed separately. Ideal for fields containing arrays of values.
4.Geospatial Indexes:
Specialized indexes for efficient queries on geographical data. MongoDB supports 2d and 2dsphere indexes for spatial coordinate-based queries.
5.Dropping an Index:
Use the dropIndex() method to remove an existing index from a collection.